### PR TITLE
Update kubernetes-cheatsheet.md

### DIFF
--- a/kubernetes-cheatsheet.md
+++ b/kubernetes-cheatsheet.md
@@ -41,8 +41,8 @@ brought to you by [Sematext](https://sematext.com/kubernetes) ![](https://semate
 	  name: mysecret
 	type: Opaque
 	data:
-	  password: $(echo "s33msi4" | base64)
-	  username: $(echo "jane" | base64)
+	  password: $(echo -n "s33msi4" | base64)
+	  username: $(echo -n "jane" | base64)
 	EOF
 	```
 


### PR DESCRIPTION
echo adds a new line in the end, which is also base64'd. echo -n should be used to avoid that behavior.